### PR TITLE
Add allocator support

### DIFF
--- a/.circleci/CMakeLists.txt
+++ b/.circleci/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(coro-travis)
+project(coro-circleci)
 cmake_minimum_required(VERSION 3.10)
 
 ## Opt in to tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,8 @@ executors:
     docker:
     - image: kayess/cpp
     environment:
-      CC: clang-12
-      CXX: clang++-12
+      CC: clang
+      CXX: clang++
       CXXFLAGS: "-stdlib=libc++"
       LD_FLAGS: "-stdlib=libc++"
   gcc:

--- a/Allocators.md
+++ b/Allocators.md
@@ -13,8 +13,6 @@ The standard library supports two mechanisms to signal that an allocator should 
 
 Because the allocator must be used by the promise type the `operator new` for the promise type is given access to the arguments of the coroutine so that it can see the allocator. However, C++ doesn't provide any simple mechanism to find the last argument of variadic pack, so only really the second mechanism makes any sense -- it is unfortunate that it is also so ugly :-(
 
-Promise types in this library support this second mechanism for all coroutine kinds through the use of `felspar::coro::promise_allocator_impl`.
-
 
 ## Using a pre-specified allocator type
 
@@ -34,3 +32,5 @@ using allocated_stream = felspar::coro::stream<T, my_allocator>;
 ```
 
 If the first argument passed to the coroutine is an l-reference to the specified allocator type (or is a sub-class of it) then the allocator will be automatically used when allocating the coroutine stack frame. If the first argument doesn't match then the normal (global `operator new`) allocation is done.
+
+Promise types in this library support this mechanism for all coroutine kinds through the use of `felspar::coro::promise_allocator_impl`. Specialisations (partial or full) of this type may be added for the concrete allocator types that are to be used, with the default implementation depending on a allocator type which implements `allocate` and `deallocate`.

--- a/Allocators.md
+++ b/Allocators.md
@@ -1,0 +1,17 @@
+# Allocator support
+
+
+Because every call to a coroutine involves a heap allocation for the coroutine promise it's very important to be able to use allocators for achieve the best performance when using coroutines.
+
+
+## Using `std::allocator_arg_t`
+
+The standard library uses two mechanisms to signal that an allocator should be used:
+
+1. Add an allocator at the end of the argument list (for example, [the `std::vector` constructors](https://en.cppreference.com/w/cpp/container/vector/vector))
+2. Use tag dispatch with the allocator at beginning of the argument list. This is done by having the allocator as the second argument following an argument of type `std::allocator_arg_t` (for example, [the `std::tuple` constructors](https://en.cppreference.com/w/cpp/utility/tuple/tuple)).
+
+Because the allocator must be used by the promise type the `operator new` for the promise type is given access to the arguments of the coroutine so that it can see the allocator. However, C++ doesn't provide any simple mechanism to find the last argument of variadic pack, so only really the second mechanism makes any sense -- it is unfortunate that it is also so ugly :-(
+
+Promise types in this library support this second mechanism for all coroutine kinds through the use of `felspar::coro::promise_allocator_impl`.
+

--- a/Allocators.md
+++ b/Allocators.md
@@ -1,12 +1,12 @@
 # Allocator support
 
 
-Because every call to a coroutine involves a heap allocation for the coroutine promise it's very important to be able to use allocators for achieve the best performance when using coroutines.
+Because every call to a coroutine involves a heap allocation for the coroutine promise, it's very important to be able to use allocators to achieve the best performance when using coroutines.
 
 
 ## Using `std::allocator_arg_t`
 
-The standard library uses two mechanisms to signal that an allocator should be used:
+The standard library supports two mechanisms to signal that an allocator should be used during object construction:
 
 1. Add an allocator at the end of the argument list (for example, [the `std::vector` constructors](https://en.cppreference.com/w/cpp/container/vector/vector))
 2. Use tag dispatch with the allocator at beginning of the argument list. This is done by having the allocator as the second argument following an argument of type `std::allocator_arg_t` (for example, [the `std::tuple` constructors](https://en.cppreference.com/w/cpp/utility/tuple/tuple)).
@@ -15,3 +15,22 @@ Because the allocator must be used by the promise type the `operator new` for th
 
 Promise types in this library support this second mechanism for all coroutine kinds through the use of `felspar::coro::promise_allocator_impl`.
 
+
+## Using a pre-specified allocator type
+
+The coroutine return types (`task`, `generator` and `stream`) also support the use of a pre-arranged allocator type. This allows a custom allocator to be used when constructing the coroutine frame without the need to use `std::allocator_arg_t`.
+
+The allocator type should be specified as the second type argument to each of them:
+
+```
+template<typename T>
+using allocated_task = felspar::coro::task<T, my_allocator>;
+
+template<typename T>
+using allocated_generator = felspar::coro::generator<T, my_allocator>;
+
+template<typename T>
+using allocated_stream = felspar::coro::stream<T, my_allocator>;
+```
+
+If the first argument passed to the coroutine is an l-reference to the specified allocator type (or is a sub-class of it) then the allocator will be automatically used when allocating the coroutine stack frame. If the first argument doesn't match then the normal (global `operator new`) allocation is done.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -6,3 +6,6 @@ target_link_libraries(primes-2-stream felspar-coro)
 
 add_executable(primes-3-optimised primes-3-optimised.cpp)
 target_link_libraries(primes-3-optimised felspar-coro)
+
+add_executable(primes-4-allocator primes-4-allocator.cpp)
+target_link_libraries(primes-4-allocator felspar-coro)

--- a/examples/primes-4-allocator.cpp
+++ b/examples/primes-4-allocator.cpp
@@ -1,0 +1,41 @@
+#include <felspar/coro/stream.hpp>
+#include <felspar/coro/task.hpp>
+#include <felspar/memory/stack.storage.hpp>
+
+#include <cstdint>
+#include <iostream>
+
+
+using integer = std::uint64_t;
+
+
+namespace {
+    using allocator = felspar::memory::stack_storage<>;
+
+    felspar::coro::stream<integer, allocator> numbers(integer upto) {
+        for (integer number{2}; number <= upto; ++number) { co_yield number; }
+    }
+    felspar::coro::stream<integer, allocator>
+            sieve(integer prime,
+                  felspar::coro::stream<integer, allocator> sieve) {
+        for (auto checking = prime; auto value = co_await sieve.next();) {
+            while (checking < *value) { checking += prime; }
+            if (checking > *value) { co_yield *value; }
+        }
+    }
+
+    felspar::coro::task<int> co_main() {
+        integer found{};
+        for (auto primes = numbers(1'000);
+             auto prime = co_await primes.next();) {
+            std::cout << *prime << ' ';
+            ++found;
+            primes = sieve(*prime, std::move(primes));
+        }
+        std::cout << "\nFound " << found << " primes\n";
+        co_return 0;
+    }
+}
+
+
+int main() { return co_main().get(); }

--- a/examples/primes-4-allocator.cpp
+++ b/examples/primes-4-allocator.cpp
@@ -10,7 +10,7 @@ using integer = std::uint64_t;
 
 
 namespace {
-    using allocator = felspar::memory::stack_storage<>;
+    using allocator = felspar::memory::stack_storage<40 << 20, 100'000>;
 
     felspar::coro::stream<integer, allocator>
             numbers(allocator &, integer upto) {
@@ -27,9 +27,10 @@ namespace {
     }
 
     felspar::coro::task<int> co_main() {
-        allocator alloc;
+        auto palloc = std::make_unique<allocator>();
+        auto &alloc = *palloc;
         integer found{};
-        for (auto primes = numbers(alloc, 1'000);
+        for (auto primes = numbers(alloc, 1'000'000);
              auto prime = co_await primes.next();) {
             std::cout << *prime << ' ';
             ++found;

--- a/examples/primes-4-allocator.cpp
+++ b/examples/primes-4-allocator.cpp
@@ -1,6 +1,6 @@
 #include <felspar/coro/stream.hpp>
 #include <felspar/coro/task.hpp>
-#include <felspar/memory/stack.storage.hpp>
+#include <felspar/memory/slab.storage.hpp>
 
 #include <cstdint>
 #include <iostream>
@@ -10,7 +10,7 @@ using integer = std::uint64_t;
 
 
 namespace {
-    using allocator = felspar::memory::stack_storage<40 << 20, 100'000>;
+    using allocator = felspar::memory::slab_storage<40 << 20>;
 
     felspar::coro::stream<integer, allocator>
             numbers(allocator &, integer upto) {

--- a/include/felspar/coro/allocator.hpp
+++ b/include/felspar/coro/allocator.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 
+#include <felspar/memory/any_buffer.hpp>
 #include <cstddef>
 #include <stdexcept>
 
@@ -15,11 +16,38 @@ namespace felspar::coro {
 
     template<>
     struct promise_allocator_impl<void> {
-        void *operator new(std::size_t const size) {
-            return ::operator new(size);
+        struct allocation {
+            /// Delete the promise
+            void (*promise_deleter)(felspar::memory::any_buffer &, void *);
+            /// Store allocation details
+            felspar::memory::any_buffer allocator;
+        };
+
+        /// Calculate the lowest offset for an aligned memory block above the
+        /// base offset
+        static std::size_t aligned_offset(std::size_t const base) {
+            std::size_t const alignment = alignof(allocation);
+            return (base + alignment - 1) & ~(alignment - 1);
         }
-        void operator delete(void *const ptr, std::size_t const size) {
-            return ::operator delete(ptr);
+
+        void *operator new(std::size_t const psize) {
+            auto const alloc_base = aligned_offset(psize);
+            auto const size = alloc_base + sizeof(allocation);
+            std::unique_ptr<std::byte> base{::new std::byte[size]};
+            new (base.get() + alloc_base)
+                    allocation{[](felspar::memory::any_buffer &, void *ptr) {
+                        ::delete[](reinterpret_cast<std::byte *>(ptr));
+                    }};
+            return base.release();
+        }
+        void operator delete(void *const ptr, std::size_t const psize) {
+            auto const alloc_base = aligned_offset(psize);
+            std::byte *const base = reinterpret_cast<std::byte *>(ptr);
+            allocation *palloc = std::launder(
+                    reinterpret_cast<allocation *>(base + alloc_base));
+            auto alloc = std::move(*palloc);
+            std::destroy_at(palloc);
+            alloc.promise_deleter(alloc.allocator, ptr);
         }
     };
 
@@ -28,6 +56,22 @@ namespace felspar::coro {
     struct promise_allocator_impl : public promise_allocator_impl<void> {
         using promise_allocator_impl<void>::operator new;
         using promise_allocator_impl<void>::operator delete;
+
+        template<typename... Args>
+        void *operator new(
+                std::size_t const psize, Allocator &alloc, Args &&...) {
+            auto const alloc_base = aligned_offset(psize);
+            auto const size = alloc_base + sizeof(allocation);
+            std::unique_ptr<std::byte> base{alloc.allocate(size)};
+            new (base.get() + alloc_base) allocation{
+                    [](felspar::memory::any_buffer &b, void *ptr) {
+                        auto palloc = b.fetch<Allocator *>();
+                        (*palloc)->deallocate(
+                                reinterpret_cast<std::byte *>(ptr));
+                    },
+                    &alloc};
+            return base.release();
+        }
     };
 
 

--- a/include/felspar/coro/allocator.hpp
+++ b/include/felspar/coro/allocator.hpp
@@ -26,8 +26,8 @@ namespace felspar::coro {
 
     template<typename Allocator>
     struct promise_allocator_impl : public promise_allocator_impl<void> {
-        using operator new;
-        using operator delete;
+        using promise_allocator_impl<void>::operator new;
+        using promise_allocator_impl<void>::operator delete;
     };
 
 

--- a/include/felspar/coro/allocator.hpp
+++ b/include/felspar/coro/allocator.hpp
@@ -68,7 +68,7 @@ namespace felspar::coro {
                     reinterpret_cast<allocation *>(base + alloc_base);
             if (palloc->allocator) {
                 auto *alloc = palloc->allocator;
-                alloc->deallocate(reinterpret_cast<std::byte *>(ptr));
+                alloc->deallocate(ptr);
             } else {
                 ::operator delete(ptr);
             }

--- a/include/felspar/coro/allocator.hpp
+++ b/include/felspar/coro/allocator.hpp
@@ -1,8 +1,7 @@
 #pragma once
 
 
-#include <felspar/memory/any_buffer.hpp>
-#include <stdexcept>
+#include <cstddef>
 
 
 namespace felspar::coro {
@@ -29,6 +28,7 @@ namespace felspar::coro {
             Allocator *allocator = nullptr;
         };
 
+        /// TODO This should be felspar-memory
         /// Calculate the lowest offset for an aligned memory block above the
         /// base offset
         static std::size_t aligned_offset(std::size_t const base) {

--- a/include/felspar/coro/allocator.hpp
+++ b/include/felspar/coro/allocator.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+
+#include <cstddef>
+#include <stdexcept>
+
+
+namespace felspar::coro {
+
+
+    /// Allocator implementation for
+    template<typename Allocator>
+    struct promise_allocator_impl;
+
+
+    template<>
+    struct promise_allocator_impl<void> {
+        void *operator new(std::size_t const size) {
+            return ::operator new(size);
+        }
+        void operator delete(void *const ptr, std::size_t const size) {
+            return ::operator delete(ptr);
+        }
+    };
+
+
+    template<typename Allocator>
+    struct promise_allocator_impl : public promise_allocator_impl<void> {
+        using operator new;
+        using operator delete;
+    };
+
+
+}

--- a/include/felspar/coro/start.hpp
+++ b/include/felspar/coro/start.hpp
@@ -9,10 +9,11 @@
 namespace felspar::coro {
 
 
+    template<typename Task>
     class starter {
       public:
-        using promise_type = felspar::coro::task_promise<void>;
-        using handle_type = promise_type::handle_type;
+        using promise_type = typename Task::promise_type;
+        using handle_type = typename promise_type::handle_type;
 
         template<typename... PArgs, typename... MArgs>
         void post(coro::task<void> (*f)(PArgs...), MArgs &&...margs) {

--- a/include/felspar/coro/stream.hpp
+++ b/include/felspar/coro/stream.hpp
@@ -9,7 +9,7 @@
 namespace felspar::coro {
 
 
-    template<typename Y, typename Allocator = void>
+    template<typename Y, typename Allocator>
     struct stream_promise;
 
 

--- a/include/felspar/coro/stream.hpp
+++ b/include/felspar/coro/stream.hpp
@@ -11,7 +11,7 @@ namespace felspar::coro {
 
     template<typename Y, typename H>
     class stream_awaitable;
-    template<typename Y, typename Allocator = void>
+    template<typename Y, typename Allocator>
     struct stream_promise;
 
 

--- a/include/felspar/coro/stream.hpp
+++ b/include/felspar/coro/stream.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 
+#include <felspar/coro/allocator.hpp>
 #include <felspar/coro/coroutine.hpp>
 #include <felspar/memory/holding_pen.hpp>
 
@@ -10,20 +11,20 @@ namespace felspar::coro {
 
     template<typename Y, typename H>
     class stream_awaitable;
-    template<typename Y>
+    template<typename Y, typename Allocator = void>
     struct stream_promise;
 
 
-    template<typename Y>
+    template<typename Y, typename Allocator = void>
     class stream final {
-        friend struct stream_promise<Y>;
-        using handle_type = typename stream_promise<Y>::handle_type;
+        friend struct stream_promise<Y, Allocator>;
+        using handle_type = typename stream_promise<Y, Allocator>::handle_type;
         handle_type yielding_coro;
 
         stream(handle_type h) : yielding_coro{std::move(h)} {}
 
       public:
-        using promise_type = stream_promise<Y>;
+        using promise_type = stream_promise<Y, Allocator>;
 
         /// Not copyable
         stream(stream const &) = delete;
@@ -37,8 +38,11 @@ namespace felspar::coro {
     };
 
 
-    template<typename Y>
-    struct stream_promise {
+    template<typename Y, typename Allocator>
+    struct stream_promise : private promise_allocator_impl<Allocator> {
+        using promise_allocator_impl<Allocator>::operator new;
+        using promise_allocator_impl<Allocator>::operator delete;
+
         coroutine_handle<> continuation = {};
         bool completed = false;
         memory::holding_pen<Y> value = {};
@@ -63,7 +67,7 @@ namespace felspar::coro {
         }
 
         auto get_return_object() {
-            return stream<Y>{handle_type::from_promise(*this)};
+            return stream<Y, Allocator>{handle_type::from_promise(*this)};
         }
 
         auto initial_suspend() const noexcept { return suspend_always{}; }
@@ -97,16 +101,16 @@ namespace felspar::coro {
       private:
         H &yielding_coro;
     };
-    template<typename Y>
-    inline stream_awaitable<Y, typename stream<Y>::handle_type>
-            stream<Y>::next() {
+    template<typename Y, typename A>
+    inline stream_awaitable<Y, typename stream<Y, A>::handle_type>
+            stream<Y, A>::next() {
         return {yielding_coro};
     }
 
 
     /// Can be used to pipe streams into other streams
-    template<typename Y, typename X>
-    inline X operator|(stream<Y> &&s, X (*c)(stream<Y>)) {
+    template<typename Y, typename YA, typename X, typename XA>
+    inline X operator|(stream<Y, YA> &&s, X (*c)(stream<Y, XA>)) {
         return c(std::move(s));
     }
 

--- a/include/felspar/coro/task.hpp
+++ b/include/felspar/coro/task.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 
+#include <felspar/coro/allocator.hpp>
 #include <felspar/coro/coroutine.hpp>
 
 #include <optional>
@@ -17,7 +18,10 @@ namespace felspar::coro {
 
 
     template<typename Allocator>
-    struct task_promise_base {
+    struct task_promise_base : private promise_allocator_impl<Allocator> {
+        using promise_allocator_impl<Allocator>::operator new;
+        using promise_allocator_impl<Allocator>::operator delete;
+
         /// Flag to ensure the coroutine is started at appropriate points in time
         bool started = false;
         /// Any caught exception that needs to be re-thrown is captured here

--- a/test/headers/CMakeLists.txt
+++ b/test/headers/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(coro-headers-tests STATIC EXCLUDE_FROM_ALL
+        allocator.cpp
         always.cpp
         lazy.cpp
         task.cpp

--- a/test/headers/CMakeLists.txt
+++ b/test/headers/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(coro-headers-tests STATIC EXCLUDE_FROM_ALL
+        allocator.cpp
         always.cpp
         cancellable.cpp
         lazy.cpp

--- a/test/headers/allocator.cpp
+++ b/test/headers/allocator.cpp
@@ -1,0 +1,1 @@
+#include <felspar/coro/allocator.hpp>

--- a/test/run/generator.cpp
+++ b/test/run/generator.cpp
@@ -7,6 +7,7 @@
 
 
 #include <felspar/coro/generator.hpp>
+#include <felspar/memory/stack.storage.hpp>
 #include <felspar/test.hpp>
 
 #include <vector>
@@ -132,6 +133,26 @@ namespace {
                         check(t.next()) == 55u;
                         check(t.next()).is_falsey();
                     });
+
+
+#ifndef NDEBUG
+    felspar::coro::generator<std::size_t, felspar::memory::stack_storage<>>
+            alloc_fib(felspar::memory::stack_storage<> &) {
+        std::size_t a{1}, b{1};
+        co_yield 1u;
+        while (true) { co_yield a = std::exchange(b, a + b); }
+    }
+
+
+    auto const al = felspar::testsuite("generator/allocator")
+                            .test("alloc", [](auto check) {
+                                felspar::memory::stack_storage alloc;
+                                auto const start_free = alloc.free();
+
+                                auto fib = alloc_fib(alloc);
+                                check(alloc.free()) < start_free;
+                            });
+#endif
 
 
 }


### PR DESCRIPTION
This is going to add (opt in) allocator support for the stack frames of the coroutines.

For an allocator to be used the first argument type must match the type specified in the `Allocator` type argument of the `task`, `stream` or `generator`.