### PR TITLE
Align allocator expectation with PMR

### DIFF
--- a/include/felspar/coro/allocator.hpp
+++ b/include/felspar/coro/allocator.hpp
@@ -68,8 +68,9 @@ namespace felspar::coro {
             allocation *palloc =
                     reinterpret_cast<allocation *>(base + alloc_base);
             if (palloc->allocator) {
+                auto const size = alloc_base + sizeof(allocation);
                 auto *alloc = palloc->allocator;
-                alloc->deallocate(ptr, psize);
+                alloc->deallocate(ptr, size);
             } else {
                 ::operator delete(ptr);
             }

--- a/include/felspar/coro/allocator.hpp
+++ b/include/felspar/coro/allocator.hpp
@@ -49,7 +49,8 @@ namespace felspar::coro {
         void *operator new(std::size_t const psize, Allocator &alloc, Args &...) {
             auto const alloc_base = aligned_offset(psize);
             auto const size = alloc_base + sizeof(allocation);
-            std::byte *base{alloc.allocate(size)};
+            std::byte *base{
+                    reinterpret_cast<std::byte *>(alloc.allocate(size))};
             new (base + alloc_base) allocation{&alloc};
             return base;
         }

--- a/include/felspar/coro/allocator.hpp
+++ b/include/felspar/coro/allocator.hpp
@@ -68,7 +68,7 @@ namespace felspar::coro {
                     reinterpret_cast<allocation *>(base + alloc_base);
             if (palloc->allocator) {
                 auto *alloc = palloc->allocator;
-                alloc->deallocate(ptr);
+                alloc->deallocate(ptr, psize);
             } else {
                 ::operator delete(ptr);
             }


### PR DESCRIPTION
Tiny change to align the allocators that are expected by default with the `std::pmr::memory_resource` API.