### PR TITLE
Starter improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(felspar-coro)
 if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
     add_custom_target(felspar-check)
     set_property(TARGET felspar-check PROPERTY EXCLUDE_FROM_ALL TRUE)
+    add_custom_target(felspar-examples)
     include(requirements.cmake)
 endif()
 
@@ -20,7 +21,9 @@ endif()
 target_link_libraries(felspar-coro INTERFACE felspar-memory)
 install(DIRECTORY include/felspar DESTINATION include)
 
-add_subdirectory(examples)
+if(TARGET felspar-examples)
+    add_subdirectory(examples)
+endif()
 
 if(TARGET felspar-check)
     add_subdirectory(test)

--- a/do-build
+++ b/do-build
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+time (
+        # User specified targets
+        ninja -C ./build.tmp/clang-debug $* &&
+        # Debug builds
+        ninja -C ./build.tmp/clang-debug all felspar-check &&
+        ninja -C ./build.tmp/gcc-debug all felspar-check &&
+        # Release builds
+        ninja -C ./build.tmp/clang-release all felspar-check &&
+        ninja -C ./build.tmp/gcc-release all felspar-check &&
+        true
+    ) && (
+        find ./examples/ ./include/ ./test/ -name \*.\?pp -print | xargs clang-format -i
+    )

--- a/include/felspar/coro/start.hpp
+++ b/include/felspar/coro/start.hpp
@@ -9,7 +9,7 @@
 namespace felspar::coro {
 
 
-    template<typename Task>
+    template<typename Task = task<void>>
     class starter {
       public:
         using promise_type = typename Task::promise_type;

--- a/include/felspar/coro/start.hpp
+++ b/include/felspar/coro/start.hpp
@@ -12,11 +12,12 @@ namespace felspar::coro {
     template<typename Task = task<void>>
     class starter {
       public:
-        using promise_type = typename Task::promise_type;
+        using task_type = Task;
+        using promise_type = typename task_type::promise_type;
         using handle_type = typename promise_type::handle_type;
 
         template<typename... PArgs, typename... MArgs>
-        void post(coro::task<void> (*f)(PArgs...), MArgs &&...margs) {
+        void post(task_type (*f)(PArgs...), MArgs &&...margs) {
             auto task = f(std::forward<MArgs>(margs)...);
             auto coro = task.release();
             coro.resume();

--- a/test/run/CMakeLists.txt
+++ b/test/run/CMakeLists.txt
@@ -2,6 +2,7 @@ if(TARGET felspar-check)
     add_test_run(felspar-check felspar-coro TESTS
             generator.cpp
             lazy.cpp
+            starter.cpp
             task.cpp
         )
 endif()

--- a/test/run/starter.cpp
+++ b/test/run/starter.cpp
@@ -1,0 +1,50 @@
+#include <felspar/coro/start.hpp>
+#include <felspar/exceptions.hpp>
+#include <felspar/test.hpp>
+
+
+namespace {
+
+
+    felspar::coro::task<void> co_throw(felspar::source_location loc) {
+        throw felspar::stdexcept::runtime_error{"A test exception", loc};
+        co_return;
+    }
+    felspar::coro::task<bool> co_true() { co_return true; }
+
+
+    auto const s = felspar::testsuite(
+            "starter",
+            [](auto check) {
+                felspar::coro::starter<> s;
+                s.post(co_throw, felspar::source_location::current());
+                check(s.size()) == 1u;
+                s.garbage_collect_completed();
+                check(s.size()) == 0u;
+            },
+            [](auto check) {
+                felspar::coro::starter<felspar::coro::task<bool>> s;
+                s.post(co_true);
+                check(s.size()) == 1u;
+                s.garbage_collect_completed();
+                check(s.size()) == 0u;
+            },
+            [](auto check) {
+                felspar::coro::starter<> s;
+                s.post(co_throw, felspar::source_location::current());
+                check(s.size()) == 1u;
+                check([&]() { s.wait_for_all().get(); })
+                        .throws(felspar::stdexcept::runtime_error{
+                                "A test exception"});
+                check(s.size()) == 0u;
+            },
+            [](auto check) {
+                felspar::coro::starter<felspar::coro::task<bool>> s;
+                s.post(co_true);
+                check(s.size()) == 1u;
+                check(s.wait_for_all().get()) == 1u;
+                check(s.size()) == 0u;
+            });
+
+
+}


### PR DESCRIPTION
This fixes the problems with the old `gc()` API on the `start` type for managing multiple coroutines.