### PR TITLE
Generator to handle move-only types

### DIFF
--- a/config-builds
+++ b/config-builds
@@ -17,6 +17,15 @@ $CMAKE -B build.tmp/gcc-release \
 
 export CC=clang
 export CXX=clang++
+
+$CMAKE -B build.tmp/clang-debug \
+    -DCMAKE_INSTALL_PREFIX=dist/clang-debug-libc++
+
+$CMAKE -B build.tmp/clang-release \
+    -DCMAKE_INSTALL_PREFIX=dist/clang-release-libc++ \
+    -DCMAKE_BUILD_TYPE=Release
+
+
 export CXXFLAGS=-stdlib=libc++
 
 $CMAKE -B build.tmp/clang-debug-libc++ \

--- a/do-build
+++ b/do-build
@@ -9,6 +9,9 @@ time (
         # Release builds
         ninja -C ./build.tmp/clang-release-libc++ all felspar-check &&
         ninja -C ./build.tmp/gcc-release all felspar-check &&
+        # libstdc++
+        ninja -C ./build.tmp/clang-debug all felspar-check &&
+        ninja -C ./build.tmp/clang-release all felspar-check &&
         # stdlib=libc++ asan
         ninja -C ./build.tmp/clang-debug-asan all felspar-check &&
         ninja -C ./build.tmp/clang-release-asan all felspar-check &&

--- a/examples/primes-1-generator.cpp
+++ b/examples/primes-1-generator.cpp
@@ -51,7 +51,7 @@ namespace {
              * If the number we're checking against is too low then keep adding
              * the prime we're checking until.
              */
-            while (checking < value) { checking += prime; }
+            while (checking < *value) { checking += prime; }
             /**
              * We're now in one of two things situations:
              *
@@ -67,7 +67,7 @@ namespace {
              * this is lower down in the sieve, so we yield it to the next layer
              * up.
              */
-            if (checking > value) { co_yield *value; }
+            if (checking > *value) { co_yield *value; }
         }
     }
 }


### PR DESCRIPTION
Replaces the use of `std::optional` with `holding_pen` so that move-only types can be yielded properly from the generator.