### PR TITLE
cmake: allow to work with modern Clang compiler.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.28)
+cmake_minimum_required(VERSION 3.14...3.28)
 project(felspar-coro LANGUAGES CXX)
 enable_testing()
 
@@ -38,7 +38,7 @@ add_library(felspar-coro INTERFACE)
 target_include_directories(felspar-coro INTERFACE include)
 target_compile_options(felspar-coro INTERFACE ${coro_opt})
 target_link_libraries(felspar-coro INTERFACE felspar-memory)
-install(DIRECTORY include/felspar DESTINATION include)
+install(DIRECTORY include/felspar TYPE INCLUDE)
 
 if(TARGET felspar-examples)
     add_subdirectory(examples)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,19 @@
-cmake_minimum_required(VERSION 3.10)
-project(felspar-coro)
+cmake_minimum_required(VERSION 3.12...3.28)
+project(felspar-coro LANGUAGES CXX)
+enable_testing()
+
+set(CMAKE_CXX_STANDARD 20)
+
+include(CheckCXXSymbolExists)
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|NVHPC")
+  set(CMAKE_REQUIRED_FLAGS -fcoroutines)
+endif()
+
+check_cxx_symbol_exists(__cpp_impl_coroutine "" have_coroutine)
+check_cxx_symbol_exists(__cpp_lib_coroutine "coroutine" have_coroutine_lib)
+if(NOT (have_coroutine AND have_coroutine_lib))
+  message(WARNING "C++20 coroutine support not detected.")
+endif()
 
 if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
     add_custom_target(felspar-check)
@@ -8,19 +22,21 @@ if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
     include(requirements.cmake)
 endif()
 
+
+set(coro_opt)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 16)
+  set(coro_opt "$<$<COMPILE_LANGUAGE:CXX>:-fcoroutines-ts;-Wno-deprecated-experimental-coroutine>")
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+  set(coro_opt "$<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-experimental-coroutine>")
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC")
+  set(coro_opt "$<$<COMPILE_LANGUAGE:CXX>:-fcoroutines>")
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  set(coro_opt "$<$<COMPILE_LANGUAGE:CXX>:-fcoroutines;-Wno-mismatched-new-delete>")
+endif()
+
 add_library(felspar-coro INTERFACE)
 target_include_directories(felspar-coro INTERFACE include)
-target_compile_features(felspar-coro INTERFACE cxx_std_20)
-if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" OR ${CMAKE_CXX_COMPILER_ID} STREQUAL "AppleClang")
-    target_compile_options(felspar-coro INTERFACE -fcoroutines-ts -Wno-deprecated-experimental-coroutine)
-elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
-    target_compile_options(felspar-coro INTERFACE
-            -fcoroutines
-            -Wno-mismatched-new-delete
-        )
-else()
-    message(SEND_ERROR "Unknown compiler ID: ${CMAKE_CXX_COMPILER_ID}")
-endif()
+target_compile_options(felspar-coro INTERFACE ${coro_opt})
 target_link_libraries(felspar-coro INTERFACE felspar-memory)
 install(DIRECTORY include/felspar DESTINATION include)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,11 +1,11 @@
 add_executable(primes-1-generator primes-1-generator.cpp)
-target_link_libraries(primes-1-generator felspar-coro)
+target_link_libraries(primes-1-generator PRIVATE felspar-coro)
 
 add_executable(primes-2-stream primes-2-stream.cpp)
-target_link_libraries(primes-2-stream felspar-coro)
+target_link_libraries(primes-2-stream PRIVATE felspar-coro)
 
 add_executable(primes-3-optimised primes-3-optimised.cpp)
-target_link_libraries(primes-3-optimised felspar-coro)
+target_link_libraries(primes-3-optimised PRIVATE felspar-coro)
 
 add_executable(primes-4-allocator primes-4-allocator.cpp)
-target_link_libraries(primes-4-allocator felspar-coro)
+target_link_libraries(primes-4-allocator PRIVATE felspar-coro)

--- a/requirements.cmake
+++ b/requirements.cmake
@@ -4,32 +4,25 @@ FetchContent_Declare(
         felspar-test
         GIT_REPOSITORY https://github.com/Felspar/test.git
         GIT_TAG main
+        GIT_SHALLOW true
     )
-FetchContent_GetProperties(felspar-test)
-if(NOT felspar-test_POPULATED)
-    FetchContent_Populate(felspar-test)
-    add_subdirectory(${felspar-test_SOURCE_DIR} ${felspar-test_BINARY_DIR})
-endif()
+FetchContent_MakeAvailable(felspar-test)
+
 
 
 FetchContent_Declare(
         felspar-exceptions
         GIT_REPOSITORY https://github.com/Felspar/exceptions.git
         GIT_TAG main
+        GIT_SHALLOW true
     )
-FetchContent_GetProperties(felspar-exceptions)
-if(NOT felspar-exceptions_POPULATED)
-    FetchContent_Populate(felspar-exceptions)
-    add_subdirectory(${felspar-exceptions_SOURCE_DIR} ${felspar-exceptions_BINARY_DIR})
-endif()
+FetchContent_MakeAvailable(felspar-exceptions)
+
 
 FetchContent_Declare(
         felspar-memory
         GIT_REPOSITORY https://github.com/Felspar/memory.git
         GIT_TAG main
+        GIT_SHALLOW true
     )
-FetchContent_GetProperties(felspar-memory)
-if(NOT felspar-memory_POPULATED)
-    FetchContent_Populate(felspar-memory)
-    add_subdirectory(${felspar-memory_SOURCE_DIR} ${felspar-memory_BINARY_DIR})
-endif()
+FetchContent_MakeAvailable(felspar-memory)

--- a/test/headers/CMakeLists.txt
+++ b/test/headers/CMakeLists.txt
@@ -9,5 +9,5 @@ add_library(coro-headers-tests STATIC EXCLUDE_FROM_ALL
         start.cpp
         task.cpp
     )
-target_link_libraries(coro-headers-tests felspar-coro)
+target_link_libraries(coro-headers-tests PRIVATE felspar-coro)
 add_dependencies(felspar-check coro-headers-tests)


### PR DESCRIPTION
* C++20 requires CMake >= 3.12
* restrict compiler flags to C++ lang
* Add feature macro check to tell user right away their compiler may not work.
* partially work with NVDIA HPC SDK (may be compiler bug)
* Works with Intel oneAPI, AMD AOCC, MSVC 

Prior to this, cannot build with modern Clang compiler.

