### PR TITLE
Clang attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,3 +130,12 @@ An asynchronous future that can be set and read from non-coroutines, but also aw
 ## Debugging
 
 * There's a useful clang document about [debugging coroutines with gdb](https://clang.llvm.org/docs/DebuggingCoroutines.html).
+
+
+## Clang lifetime tracking
+
+By default clang's coroutine lifetime tracking attributes are enabled, but due to the virality of the [`[[clang:coro_wrapper]]`](https://clang.llvm.org/docs/AttributeReference.html#coro-wrapper) attribute they can cause problems when you use higher order functions that manipulate coroutine return types (like `task`, `stream` etc.). To turn the attributes off define `FELSPAR_CORO_SKIP_LIFETIME_CHECKS` in your build. If you're using `add_subdirectory` to bring in the library then adding this afterwards will do it:
+
+```cmake
+target_compile_definitions(felspar-coro INTERFACE FELSPAR_CORO_SKIP_LIFETIME_CHECKS)
+```

--- a/include/felspar/coro/cancellable.hpp
+++ b/include/felspar/coro/cancellable.hpp
@@ -23,6 +23,8 @@ namespace felspar::coro {
         cancellable &operator=(cancellable const &) = delete;
         cancellable &operator=(cancellable &&) = delete;
 
+
+        /// ### `cancel`
         /// Used externally to cancel the controlled coroutine
         void cancel() {
             signalled = true;
@@ -34,10 +36,12 @@ namespace felspar::coro {
         }
         bool cancelled() const noexcept { return signalled; }
 
+
+        /// ### `signal_or`
         /// Wrap an awaitable so that an early resumption can be signalled
         template<typename A>
-        auto signal_or(A coro_awaitable) {
-            struct awaitable {
+        FELSPAR_CORO_WRAPPER auto signal_or(A coro_awaitable) {
+            struct FELSPAR_CORO_CRT awaitable {
                 A a;
                 cancellable &b;
                 coroutine_handle<> continuation = {};
@@ -48,7 +52,7 @@ namespace felspar::coro {
                     return b.signalled or a.await_ready();
                 }
                 auto await_suspend(coroutine_handle<> h) noexcept {
-                    /// `h` is the coroutine making use of the `cancellable`
+                    // `h` is the coroutine making use of the `cancellable`
                     continuation = h;
                     b.continuations.push_back(h);
                     return a.await_suspend(h);
@@ -67,9 +71,10 @@ namespace felspar::coro {
             return awaitable{std::move(coro_awaitable), *this};
         }
 
-        /// This can be directly awaited until signalled
-        auto operator co_await() {
-            struct awaitable {
+        /// ### `operator co_await`
+        /// This type can also be directly awaited until signalled
+        FELSPAR_CORO_WRAPPER auto operator co_await() {
+            struct FELSPAR_CORO_CRT awaitable {
                 cancellable &b;
                 coroutine_handle<> continuation = {};
 

--- a/include/felspar/coro/coroutine.hpp
+++ b/include/felspar/coro/coroutine.hpp
@@ -40,6 +40,22 @@ namespace felspar::coro {
 #endif
 
 
+#if defined __has_attribute
+#if false and __has_attribute(coro_return_type) \
+        and __has_attribute(coro_lifetimebound) \
+        and __has_attribute(coro_wrapper)
+#define FELSPAR_CORO_CRT [[clang::coro_return_type, clang::coro_lifetimebound]]
+#define FELSPAR_CORO_WRAPPER [[clang::coro_wrapper]]
+#endif
+#endif
+#if not defined FELSPAR_CORO_CRT
+#define FELSPAR_CORO_CRT
+#endif
+#if not defined FELSPAR_CORO_WRAPPER
+#define FELSPAR_CORO_WRAPPER
+#endif
+
+
 namespace felspar::coro {
 
 

--- a/include/felspar/coro/coroutine.hpp
+++ b/include/felspar/coro/coroutine.hpp
@@ -26,7 +26,8 @@ namespace felspar::coro {
 
 
 #if defined __has_attribute
-#if false and __has_attribute(coro_return_type) \
+#if not defined FELSPAR_CORO_SKIP_LIFETIME_CHECKS \
+        and __has_attribute(coro_return_type) \
         and __has_attribute(coro_lifetimebound) \
         and __has_attribute(coro_wrapper)
 #define FELSPAR_CORO_CRT [[clang::coro_return_type, clang::coro_lifetimebound]]

--- a/include/felspar/coro/coroutine.hpp
+++ b/include/felspar/coro/coroutine.hpp
@@ -13,21 +13,6 @@ namespace felspar::coro {
     using suspend_always = std::suspend_always;
     using suspend_never = std::suspend_never;
 }
-/**
-Super bad idea, but the sort of thing that would be needed to make
-clang work with libstdc++ as clang seems to be hard coded to look
-in the experimental namespace for things.
-```cpp
-namespace std::experimental {
-    template<typename T = void>
-    using coroutine_handle = std::coroutine_handle<T>;
-    template<typename... Ts>
-    using coroutine_traits = std::coroutine_traits<Ts...>;
-    using suspend_always = std::suspend_always;
-    using suspend_never = std::suspend_never;
-}
-```
-*/
 #else
 #include <experimental/coroutine>
 namespace felspar::coro {

--- a/include/felspar/coro/eager.hpp
+++ b/include/felspar/coro/eager.hpp
@@ -41,7 +41,9 @@ namespace felspar::coro {
         bool done() const noexcept { return coro and coro.done(); }
 
         /// #### Release the held task so it can be `co_await`ed
-        auto release() && { return task_type(std::move(coro)); }
+        FELSPAR_CORO_WRAPPER auto release() && {
+            return task_type(std::move(coro));
+        }
 
         /// #### Destroy the contained coroutine
         auto destroy() {

--- a/include/felspar/coro/future.hpp
+++ b/include/felspar/coro/future.hpp
@@ -61,8 +61,8 @@ namespace felspar::coro {
 
 
         /// ### Coroutine interface
-        auto operator co_await() {
-            struct awaitable {
+        FELSPAR_CORO_WRAPPER auto operator co_await() {
+            struct FELSPAR_CORO_CRT awaitable {
                 explicit awaitable(coro::future<value_type> &f) : fut{f} {}
                 awaitable(awaitable const &) = delete;
                 // TODO We could be movable
@@ -137,8 +137,8 @@ namespace felspar::coro {
 
 
         /// ### Coroutine interface
-        auto operator co_await() {
-            struct awaitable {
+        FELSPAR_CORO_WRAPPER auto operator co_await() {
+            struct FELSPAR_CORO_CRT awaitable {
                 explicit awaitable(coro::future<void> &f) : fut{f} {}
                 awaitable(awaitable const &) = delete;
                 // TODO We could be movable

--- a/include/felspar/coro/generator.hpp
+++ b/include/felspar/coro/generator.hpp
@@ -18,7 +18,7 @@ namespace felspar::coro {
     /// A coroutine based generator. Values may be iterated (`begin`/`end`), or
     /// values may be fetched (`next`), but not both.
     template<typename Y, typename Allocator = void>
-    class generator final {
+    class FELSPAR_CORO_CRT generator final {
         friend struct generator_promise<Y, Allocator>;
         using handle_type =
                 typename generator_promise<Y, Allocator>::handle_type;
@@ -61,6 +61,7 @@ namespace felspar::coro {
             iterator &operator=(iterator &&i) = default;
             ~iterator() = default;
 
+
             Y operator*() {
                 return static_cast<Y &&>(
                         std::move(coro.promise().value).transfer_out().value());
@@ -72,6 +73,7 @@ namespace felspar::coro {
                 if (not coro.promise().value) { coro = {}; }
                 return *this;
             }
+
 
             friend bool operator==(iterator const &l, iterator const &r) {
                 if (not l.coro && not r.coro) {
@@ -87,6 +89,7 @@ namespace felspar::coro {
         };
         auto begin() { return iterator{this}; }
         auto end() { return iterator{}; }
+
 
         /// Fetching values. Returns an empty `optional` when completed.
         memory::holding_pen<Y> next() {

--- a/include/felspar/coro/starter.hpp
+++ b/include/felspar/coro/starter.hpp
@@ -82,7 +82,8 @@ namespace felspar::coro {
         }
 
         /// ### The next item in line in the starter
-        task_type next(source_location const &loc = source_location::current()) {
+        FELSPAR_CORO_WRAPPER task_type
+                next(source_location const &loc = source_location::current()) {
             if (live.empty()) {
                 throw stdexcept::logic_error{
                         "Cannot call starter::next() if there are no items",

--- a/include/felspar/coro/stream.hpp
+++ b/include/felspar/coro/stream.hpp
@@ -18,7 +18,7 @@ namespace felspar::coro {
 
 
     template<typename Y, typename Allocator = void>
-    class stream final {
+    class FELSPAR_CORO_CRT stream final {
         friend struct stream_promise<Y, Allocator>;
         using handle_type = typename stream_promise<Y, Allocator>::handle_type;
         handle_type yielding_coro;
@@ -38,7 +38,7 @@ namespace felspar::coro {
         stream &operator=(stream &&t) noexcept = default;
         ~stream() = default;
 
-        stream_awaitable<Y, handle_type> next();
+        FELSPAR_CORO_WRAPPER stream_awaitable<Y, handle_type> next();
     };
 
 

--- a/include/felspar/coro/task.hpp
+++ b/include/felspar/coro/task.hpp
@@ -73,7 +73,7 @@ namespace felspar::coro {
         bool has_value() const noexcept { return value or eptr; }
         void return_value(value_type y) { value = std::move(y); }
 
-        value_type consume_value() {
+        FELSPAR_CORO_WRAPPER value_type consume_value() {
             check_exception();
             if (not value.has_value()) {
                 throw std::runtime_error{
@@ -88,7 +88,7 @@ namespace felspar::coro {
 
     /// ## Tasks
     template<typename Y, typename Allocator>
-    class [[nodiscard]] task final {
+    class [[nodiscard]] FELSPAR_CORO_CRT task final {
         friend class eager<task>;
         friend class starter<task>;
         friend struct task_promise<Y, Allocator>;
@@ -118,13 +118,13 @@ namespace felspar::coro {
 
         /// ### Awaitable
         auto operator co_await() & = delete;
-        auto operator co_await() && {
+        FELSPAR_CORO_WRAPPER auto operator co_await() && {
             /**
              * The awaitable takes over ownership of the coroutine handle once
              * its been created. This ensures that the lifetime of the promise
              * is long enough to deliver the return value.
              */
-            struct awaitable {
+            struct FELSPAR_CORO_CRT awaitable {
                 handle_type coro;
 
                 bool await_ready() const noexcept {
@@ -143,7 +143,9 @@ namespace felspar::coro {
                         return noop_coroutine();
                     }
                 }
-                Y await_resume() { return coro.promise().consume_value(); }
+                FELSPAR_CORO_WRAPPER Y await_resume() {
+                    return coro.promise().consume_value();
+                }
             };
             return awaitable{std::move(coro)};
         }


### PR DESCRIPTION
This attempts to add in the clang attributes for tracking coroutine lifetimes and memory bounds, unfortunately it breaks a lot of higher order code due to other attribute requirements it introduces.