### PR TITLE
Store the allocation details before the coroutine frame

### DIFF
--- a/include/felspar/coro/allocator.hpp
+++ b/include/felspar/coro/allocator.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
 
-#include <cstddef>
+#include <felspar/memory/sizes.hpp>
+
 #include <new>
+#include <utility>
 
 
 namespace felspar::coro {
@@ -16,6 +18,7 @@ namespace felspar::coro {
     template<>
     struct promise_allocator_impl<void> {
         void *operator new(std::size_t sz) { return ::operator new(sz); }
+        void operator delete(void *const ptr) { return ::operator delete(ptr); }
         void operator delete(void *const ptr, std::size_t) {
             return ::operator delete(ptr);
         }
@@ -25,56 +28,57 @@ namespace felspar::coro {
     template<typename Allocator>
     struct promise_allocator_impl {
         struct allocation {
-            /// Store allocation details
+            /// ### Size of the allocation
+            /// Includes the size of this structure and padding
+            std::size_t total_size;
+            /// ### Store allocator details
             Allocator *allocator = nullptr;
         };
 
-        // TODO This should be in felspar-memory
-        /// Calculate the lowest offset for an aligned memory block above the
-        /// base offset
-        static std::size_t aligned_offset(std::size_t const base) {
-            std::size_t const alignment = alignof(allocation);
-            return (base + alignment - 1) & ~(alignment - 1);
-        }
+        static constexpr std::size_t allocator_block_size =
+                felspar::memory::block_size(
+                        sizeof(allocation), alignof(std::max_align_t));
 
         void *operator new(std::size_t const psize) {
-            auto const alloc_base = aligned_offset(psize);
-            auto const size = alloc_base + sizeof(allocation);
-            std::byte *base{
-                    reinterpret_cast<std::byte *>(::operator new(size))};
-            new (base + alloc_base) allocation{};
-            return base;
+            std::size_t const allocation_size = allocator_block_size + psize;
+            std::byte *base{reinterpret_cast<std::byte *>(
+                    ::operator new(allocation_size))};
+            new (base) allocation{allocation_size};
+            return base + allocator_block_size;
         }
 
+        /// ### Deal with functions that are passed allocators
         template<typename... Args>
         void *operator new(std::size_t const psize, Allocator &alloc, Args &...) {
-            auto const alloc_base = aligned_offset(psize);
-            auto const size = alloc_base + sizeof(allocation);
-            std::byte *base{
-                    reinterpret_cast<std::byte *>(alloc.allocate(size))};
-            new (base + alloc_base) allocation{&alloc};
-            return base;
+            std::size_t const allocation_size = allocator_block_size + psize;
+            std::byte *base{reinterpret_cast<std::byte *>(
+                    alloc.allocate(allocation_size))};
+            new (base) allocation{allocation_size, &alloc};
+            return base + allocator_block_size;
         }
-        /// Deal with members that are coroutines. `This` should almost
-        /// certainly be much more restrictive than it is here
+        /// ### Deal with members that are coroutines
+        /// TODO `This` should almost certainly be much more restrictive than it
+        /// is here
         template<typename This, typename... Args>
         void *operator new(
                 std::size_t const sz, This &&, Allocator &alloc, Args &...) {
             return operator new(sz, alloc);
         }
 
-        void operator delete(void *const ptr, std::size_t const psize) {
-            auto const alloc_base = aligned_offset(psize);
-            std::byte *const base = reinterpret_cast<std::byte *>(ptr);
-            allocation *palloc = std::launder(
-                    reinterpret_cast<allocation *>(base + alloc_base));
-            if (palloc->allocator) {
-                auto const size = alloc_base + sizeof(allocation);
-                auto *alloc = palloc->allocator;
-                alloc->deallocate(ptr, size);
+        void operator delete(void *const ptr) {
+            auto const frame = reinterpret_cast<std::byte *>(ptr);
+            auto const base_ptr = reinterpret_cast<allocation *>(
+                    frame - allocator_block_size);
+            auto const details = std::move(*base_ptr);
+            base_ptr->~allocation();
+            if (details.allocator) {
+                details.allocator->deallocate(base_ptr, details.total_size);
             } else {
-                ::operator delete(ptr);
+                ::operator delete(base_ptr);
             }
+        }
+        void operator delete(void *const ptr, std::size_t) {
+            operator delete(ptr);
         }
     };
 


### PR DESCRIPTION
This allows us to support compilers that call `operator delete` without passing the size of the frame. The clang compiler for Android seems to do this for some reason.