### PR TITLE
Clear awaitable continuations on destruction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,10 @@ if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
     set_property(TARGET felspar-check PROPERTY EXCLUDE_FROM_ALL TRUE)
     add_custom_target(felspar-examples)
     include(requirements.cmake)
+    add_compile_options(
+            -fdiagnostics-color=always
+            -fdiagnostics-show-option
+        )
 endif()
 
 

--- a/do-build
+++ b/do-build
@@ -3,6 +3,9 @@
 time (
         # User specified targets
         ninja -C ./build.tmp/clang-debug-libc++ $* &&
+        # stdlib=libc++ asan
+        ninja -C ./build.tmp/clang-debug-asan all felspar-check &&
+        ninja -C ./build.tmp/clang-release-asan all felspar-check &&
         # Debug builds
         ninja -C ./build.tmp/clang-debug-libc++ all felspar-check &&
         ninja -C ./build.tmp/gcc-debug all felspar-check &&
@@ -12,9 +15,6 @@ time (
         # libstdc++
         ninja -C ./build.tmp/clang-debug all felspar-check &&
         ninja -C ./build.tmp/clang-release all felspar-check &&
-        # stdlib=libc++ asan
-        ninja -C ./build.tmp/clang-debug-asan all felspar-check &&
-        ninja -C ./build.tmp/clang-release-asan all felspar-check &&
         # stdlib=libc++ asan force PMR
         ninja -C ./build.tmp/clang-debug-pmr-asan all felspar-check &&
         ninja -C ./build.tmp/clang-release-pmr-asan all felspar-check &&

--- a/include/felspar/coro/stream.hpp
+++ b/include/felspar/coro/stream.hpp
@@ -87,6 +87,7 @@ namespace felspar::coro {
 
       public:
         stream_awaitable(H &c) : continuation{c} {}
+        ~stream_awaitable() { continuation.promise().continuation = {}; }
 
         bool await_ready() const noexcept {
             return continuation.promise().completed;

--- a/include/felspar/coro/task.hpp
+++ b/include/felspar/coro/task.hpp
@@ -126,6 +126,7 @@ namespace felspar::coro {
              */
             struct FELSPAR_CORO_CRT awaitable {
                 handle_type coro;
+                ~awaitable() { coro.promise().continuation = {}; }
 
                 bool await_ready() const noexcept {
                     return coro.promise().has_value();

--- a/test/run/task.cpp
+++ b/test/run/task.cpp
@@ -5,100 +5,84 @@
 namespace {
 
 
-    auto const task =
-            felspar::testsuite("task")
+    auto const suite = felspar::testsuite("task");
 
-                    .test("basic task",
-                          [](auto check) {
-                              auto answer = []() -> felspar::coro::task<int> {
-                                  co_return 42;
-                              };
-                              check(answer().get()) == 42;
-                          })
-                    .test("movable value",
-                          [](auto check) {
-                              struct X {
-                                  // Uncomment for ICE in gcc-10
-                                  // std::string member;
-                                  X() {}
-                                  X(X const &) = delete;
-                                  X(X &&) = default;
-                                  X &operator=(X const &) = delete;
-                                  X &operator=(X &&) = default;
-                                  ~X() = default;
-                                  bool operator==(X const &) const {
-                                      return true;
-                                  }
-                              };
-                              auto marks_the_spot =
-                                      []() -> felspar::coro::task<X> {
-                                  co_return X{};
-                              };
-                              check(marks_the_spot().get()) == X{};
-                          })
+    auto const bt = suite.test("basic task", [](auto check) {
+        auto answer = []() -> felspar::coro::task<int> { co_return 42; };
+        check(answer().get()) == 42;
+    });
 
-                    .test("ignored awaitable",
-                          [](auto check) {
-                              bool run = false;
-                              auto answer = [&]() -> felspar::coro::task<int> {
-                                  run = true;
-                                  co_return 42;
-                              };
-                              auto a = answer();
-                              check(run).is_falsey();
-                              check(std::move(a).get()) == 42;
-                              check(run).is_truthy();
-                          })
+    auto const mv = suite.test("movable value", [](auto check) {
+        struct X {
+            // Uncomment for ICE in gcc-10
+            // std::string member;
+            X() {}
+            X(X const &) = delete;
+            X(X &&) = default;
+            X &operator=(X const &) = delete;
+            X &operator=(X &&) = default;
+            ~X() = default;
+            bool operator==(X const &) const { return true; }
+        };
+        auto marks_the_spot = []() -> felspar::coro::task<X> { co_return X{}; };
+        check(marks_the_spot().get()) == X{};
+    });
 
-                    .test("throws",
-                          [](auto check) {
-                              bool run = false;
-                              auto throws = []() -> felspar::coro::task<int> {
-                                  throw std::runtime_error{"Test throw"};
-                                  co_return 42;
-                              };
-                              auto rt = throws();
-                              check(run).is_falsey();
-                              check([&]() {
-                                  std::move(rt).get();
-                              }).throws(std::runtime_error{"Test throw"});
-                          })
+    auto const iw = suite.test("ignored awaitable", [](auto check) {
+        bool run = false;
+        auto answer = [&]() -> felspar::coro::task<int> {
+            run = true;
+            co_return 42;
+        };
+        auto a = answer();
+        check(run).is_falsey();
+        check(std::move(a).get()) == 42;
+        check(run).is_truthy();
+    });
 
-                    .test("nested task",
-                          [](auto check) {
-                              auto doubler = []() -> felspar::coro::task<int> {
-                                  auto half_answer =
-                                          []() -> felspar::coro::task<int> {
-                                      co_return 21;
-                                  };
-                                  co_return 2 * co_await half_answer();
-                              };
-                              check(doubler().get()) == 42;
-                          })
-                    .test("awaitable must be r-value",
-                          [](auto check) {
-                              auto half_answer =
-                                      []() -> felspar::coro::task<int> {
-                                  co_return 21;
-                              };
-                              auto doubler = [](felspar::coro::task<int> n)
-                                      -> felspar::coro::task<int> {
-                                  co_return 2 * co_await std::move(n);
-                              };
-                              check(doubler(half_answer()).get()) == 42;
-                          })
-                    .test("void task", [](auto check) {
-                        bool run = false;
-                        auto const empty =
-                                [](bool &r) -> felspar::coro::task<void> {
-                            r = true;
-                            co_return;
-                        };
-                        auto t = empty(run);
-                        check(run) == false;
-                        std::move(t).get();
-                        check(run) == true;
-                    });
+    auto const t = suite.test("throws", [](auto check) {
+        bool run = false;
+        auto throws = []() -> felspar::coro::task<int> {
+            throw std::runtime_error{"Test throw"};
+            co_return 42;
+        };
+        auto rt = throws();
+        check(run).is_falsey();
+        check([&]() {
+            std::move(rt).get();
+        }).throws(std::runtime_error{"Test throw"});
+    });
+
+    auto const nt = suite.test("nested task", [](auto check) {
+        auto doubler = []() -> felspar::coro::task<int> {
+            auto half_answer = []() -> felspar::coro::task<int> {
+                co_return 21;
+            };
+            co_return 2 * co_await half_answer();
+        };
+        check(doubler().get()) == 42;
+    });
+
+    auto const ambr = suite.test("awaitable must be r-value", [](auto check) {
+        auto half_answer = []() -> felspar::coro::task<int> { co_return 21; };
+        auto doubler =
+                [](felspar::coro::task<int> n) -> felspar::coro::task<int> {
+            co_return 2 * co_await std::move(n);
+        };
+        check(doubler(half_answer()).get()) == 42;
+    });
+
+    auto const vt = suite.test("void task", [](auto check) {
+        bool run = false;
+        auto const empty = [](bool &r) -> felspar::coro::task<void> {
+            r = true;
+            co_return;
+        };
+        auto t = empty(run);
+        check(run) == false;
+        std::move(t).get();
+        check(run) == true;
+    });
 
 
 }


### PR DESCRIPTION
This makes some uses of these awaitables safer as they can now be safely destructed even though they've been awaited.