### PR TITLE
We don't need this virtual base type

### DIFF
--- a/include/felspar/coro/coroutine.hpp
+++ b/include/felspar/coro/coroutine.hpp
@@ -45,20 +45,12 @@ namespace felspar::coro {
 namespace felspar::coro {
 
 
-    /// ## Unique coroutine handle
-    /// A type erased base type for the `unique_handle`
-    struct unique_handle_base {
-        virtual ~unique_handle_base() = default;
-        virtual bool done() const noexcept = 0;
-    };
-
-
     /**
      * A wrapper around `coroutine_handle<P>` that manages the handle, calling
      * `destroy` on it when done.
      */
     template<typename P = void>
-    class unique_handle final : public unique_handle_base {
+    class unique_handle final {
         coroutine_handle<P> handle = {};
         explicit unique_handle(coroutine_handle<P> h) : handle{h} {}
 
@@ -69,7 +61,7 @@ namespace felspar::coro {
         unique_handle(unique_handle const &) = delete;
         unique_handle(unique_handle &&h) noexcept
         : handle{std::exchange(h.handle, {})} {}
-        ~unique_handle() override {
+        ~unique_handle() {
             if (handle) { handle.destroy(); }
         }
 
@@ -88,7 +80,7 @@ namespace felspar::coro {
 
         /// ### Forwarders for `coroutine_handle<P>` members
         explicit operator bool() const noexcept { return bool{handle}; }
-        bool done() const noexcept override { return handle.done(); }
+        bool done() const noexcept { return handle.done(); }
         template<typename PP>
         static auto from_promise(PP &&pp) noexcept {
             return unique_handle{


### PR DESCRIPTION
Removes the virtual base type from the coroutine handle