### PR TITLE
Compiler regressions

### DIFF
--- a/examples/primes-2-stream.cpp
+++ b/examples/primes-2-stream.cpp
@@ -14,7 +14,8 @@ namespace {
     }
     felspar::coro::stream<integer>
             sieve(integer prime, felspar::coro::stream<integer> sieve) {
-        for (auto checking = prime; auto value = co_await sieve.next();) {
+        auto checking = prime;
+        while (auto value = co_await sieve.next()) {
             while (checking < *value) { checking += prime; }
             if (checking > *value) { co_yield *value; }
         }
@@ -22,8 +23,8 @@ namespace {
 
     felspar::coro::task<int> co_main() {
         integer found{};
-        for (auto primes = numbers(1'000'000);
-             auto prime = co_await primes.next();) {
+        auto primes = numbers(1'000'000);
+        while (auto prime = co_await primes.next()) {
             std::cout << *prime << ' ';
             ++found;
             primes = sieve(*prime, std::move(primes));

--- a/examples/primes-3-optimised.cpp
+++ b/examples/primes-3-optimised.cpp
@@ -32,7 +32,8 @@ namespace {
     }
     felspar::coro::stream<integer>
             sieve(integer prime, felspar::coro::stream<integer> sieve) {
-        for (auto checking = prime; auto value = co_await sieve.next();) {
+        auto checking = prime;
+        while (auto value = co_await sieve.next()) {
             while (checking < *value) { checking += prime; }
             if (checking > *value) { co_yield *value; }
         }
@@ -52,8 +53,8 @@ namespace {
          * the way up to my very own fragile prime (thanks Matt Parker)
          * https://youtu.be/p3Khnx0lUDE?t=1682
          */
-        for (auto primes = numbers(694'183'367);
-             auto prime = co_await primes.next();) {
+        auto primes = numbers(694'183'367);
+        while (auto prime = co_await primes.next()) {
             std::cout << *prime << ' ';
             ++found;
             /**

--- a/examples/primes-4-allocator.cpp
+++ b/examples/primes-4-allocator.cpp
@@ -20,7 +20,8 @@ namespace {
             sieve(allocator &,
                   integer prime,
                   felspar::coro::stream<integer, allocator> sieve) {
-        for (auto checking = prime; auto value = co_await sieve.next();) {
+        auto checking = prime;
+        while (auto value = co_await sieve.next()) {
             while (checking < *value) { checking += prime; }
             if (checking > *value) { co_yield *value; }
         }
@@ -30,8 +31,8 @@ namespace {
         auto palloc = std::make_unique<allocator>();
         auto &alloc = *palloc;
         integer found{};
-        for (auto primes = numbers(alloc, 1'000'000);
-             auto prime = co_await primes.next();) {
+        auto primes = numbers(alloc, 1'000'000);
+        while (auto prime = co_await primes.next()) {
             std::cout << *prime << ' ';
             ++found;
             primes = sieve(alloc, *prime, std::move(primes));

--- a/include/felspar/coro/generator.hpp
+++ b/include/felspar/coro/generator.hpp
@@ -107,10 +107,7 @@ namespace felspar::coro {
 
 
     template<typename Y, typename Allocator>
-    struct generator_promise : private promise_allocator_impl<Allocator> {
-        using promise_allocator_impl<Allocator>::operator new;
-        using promise_allocator_impl<Allocator>::operator delete;
-
+    struct generator_promise : public promise_allocator_impl<Allocator> {
         memory::holding_pen<Y> value = {};
         std::exception_ptr eptr = {};
 

--- a/include/felspar/coro/lazy.hpp
+++ b/include/felspar/coro/lazy.hpp
@@ -22,10 +22,7 @@ namespace felspar::coro {
         lazy &operator=(lazy &&o) = default;
         ~lazy() = default;
 
-        struct promise_type : private promise_allocator_impl<Allocator> {
-            using promise_allocator_impl<Allocator>::operator new;
-            using promise_allocator_impl<Allocator>::operator delete;
-
+        struct promise_type : public promise_allocator_impl<Allocator> {
             std::exception_ptr eptr;
             std::optional<L> value;
             using handle_type = unique_handle<promise_type>;

--- a/include/felspar/coro/stream.hpp
+++ b/include/felspar/coro/stream.hpp
@@ -43,10 +43,7 @@ namespace felspar::coro {
 
 
     template<typename Y, typename Allocator>
-    struct stream_promise : private promise_allocator_impl<Allocator> {
-        using promise_allocator_impl<Allocator>::operator new;
-        using promise_allocator_impl<Allocator>::operator delete;
-
+    struct stream_promise : public promise_allocator_impl<Allocator> {
         std::coroutine_handle<> continuation = {};
         bool completed = false;
         memory::holding_pen<Y> value = {};

--- a/include/felspar/coro/task.hpp
+++ b/include/felspar/coro/task.hpp
@@ -14,10 +14,7 @@ namespace felspar::coro {
 
 
     template<typename Allocator>
-    struct task_promise_base : private promise_allocator_impl<Allocator> {
-        using promise_allocator_impl<Allocator>::operator new;
-        using promise_allocator_impl<Allocator>::operator delete;
-
+    struct task_promise_base : public promise_allocator_impl<Allocator> {
         /// Flag to ensure the coroutine is started at appropriate points in time
         bool started = false;
         /// Any caught exception that needs to be re-thrown is captured here

--- a/test/run/stream.cpp
+++ b/test/run/stream.cpp
@@ -37,9 +37,8 @@ namespace {
     auto const sint = suite.test("int", [](auto check) {
         [&]() -> felspar::coro::task<void> {
             int expected{};
-            for (auto nums = numbers(5); auto n = co_await nums.next();) {
-                check(*n) == expected++;
-            }
+            auto nums = numbers(5);
+            while (auto n = co_await nums.next()) { check(*n) == expected++; }
         }()
                          .get();
     });


### PR DESCRIPTION
Makes some changes to handle regressions with both clang and gcc. They've each taken different things that the code is doing and added compiler bugs for them leading to ICE.